### PR TITLE
feat: Report test status

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,5 +32,10 @@ jobs:
       - name: Run pnpm build
         run: npm run build
 
-      - name: Run tests
-        run: php artisan test # run unit tests only as I failed to figure out how to fix feature tests
+      - name: Run tests and collect coverage reports
+        run: php artisan test --coverage-clover coverage.xml
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Tridoc
 
+[![test](https://github.com/tridoc-dev/tridoc/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/tridoc-dev/tridoc/actions/workflows/test.yaml)
+
 ## Development
 
 ### Install `php` and `composer`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Tridoc
 
 [![test](https://github.com/tridoc-dev/tridoc/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/tridoc-dev/tridoc/actions/workflows/test.yaml)
+[![codecov](https://codecov.io/github/tridoc-dev/tridoc/graph/badge.svg?token=2OEX2WD3UJ)](https://codecov.io/github/tridoc-dev/tridoc)
 
 ## Development
 


### PR DESCRIPTION
Report test passing and test coverage in README.

The test coverage report is supported by Codecov, thus requires @JinBridger to add the global token `CODECOV_TOKEN` as a repository secret from [the official website](https://about.codecov.io/).

After that, we can merge the pr.